### PR TITLE
add 'find_service' and fix 'scan_services' bug

### DIFF
--- a/lualib/moon.lua
+++ b/lualib/moon.lua
@@ -29,6 +29,7 @@ local _newservice = core.new_service
 local _queryservice = core.queryservice
 local _decode = core.decode
 local _scan_services = core.scan_services
+local _find_service = core.find_service
 
 ---@class moon : core
 local moon = core
@@ -329,6 +330,14 @@ end
 ---@return string
 function moon.scan_services(workerid)
     return moon.wait(_scan_services(workerid))
+end
+
+--- Get specified service name and ID, in JSON format
+---@async
+---@param serviceid integer @ The service service.
+---@return string
+function moon.find_service(serviceid)
+    return moon.wait(_find_service(serviceid))
 end
 
 --- Sends a message to the target service and waits for a response. The receiver must call `moon.response` to return the result.

--- a/src/lualib-src/lua_moon.cpp
+++ b/src/lualib-src/lua_moon.cpp
@@ -299,6 +299,15 @@ static int lmoon_scan_services(lua_State* L) {
     return 1;
 }
 
+static int lmoon_find_service(lua_State* L) {
+    lua_service* S = lua_service::get(L);
+    auto serviceid = (uint32_t)luaL_checkinteger(L, 1);
+    int64_t sessionid = S->next_sequence();
+    S->get_server()->find_service(S->id(), serviceid, sessionid);
+    lua_pushinteger(L, sessionid);
+    return 1;
+}
+
 static int lmoon_queryservice(lua_State* L) {
     const lua_service* S = lua_service::get(L);
     std::string_view name = lua_check<std::string_view>(L, 1);
@@ -462,6 +471,7 @@ int LUAMOD_API luaopen_moon_core(lua_State* L) {
                      { "new_service", lmoon_new_service },
                      { "kill", lmoon_kill },
                      { "scan_services", lmoon_scan_services },
+                     { "find_service", lmoon_find_service },
                      { "queryservice", lmoon_queryservice },
                      { "next_sequence", lmoon_next_sequence },
                      { "env", lmoon_env },

--- a/src/moon/core/server.cpp
+++ b/src/moon/core/server.cpp
@@ -186,10 +186,20 @@ void server::remove_service(uint32_t serviceid, uint32_t sender, int64_t session
 
 void server::scan_services(uint32_t sender, uint32_t workerid, int64_t sessionid) const {
     auto* w = get_worker(workerid);
-    if (nullptr == w) {
-        return;
+    if (nullptr != w) {
+        w->scan(sender, sessionid);
+    } else {
+        response(sender, ""sv, sessionid);
     }
-    w->scan(sender, sessionid);
+}
+
+void server::find_service(uint32_t sender, uint32_t serviceid, int64_t sessionid) const {
+    auto* w = get_worker(0, serviceid);
+    if (nullptr != w) {
+        w->find(serviceid, sender, sessionid);
+    } else {
+        response(sender, ""sv, sessionid);
+    }
 }
 
 bool server::send_message(message&& m) const {

--- a/src/moon/core/server.h
+++ b/src/moon/core/server.h
@@ -71,6 +71,8 @@ public:
 
     void scan_services(uint32_t sender, uint32_t workerid, int64_t sessionid) const;
 
+    void find_service(uint32_t sender, uint32_t serviceid, int64_t sessionid) const;
+
     bool send_message(message&& msg) const;
 
     bool send(uint32_t sender, uint32_t receiver, buffer_ptr_t buf, int64_t sessionid, uint8_t type)

--- a/src/moon/core/worker.cpp
+++ b/src/moon/core/worker.cpp
@@ -176,6 +176,20 @@ void worker::scan(uint32_t sender, int64_t sessionid) {
     });
 }
 
+void worker::find(uint32_t serviceid, uint32_t sender, int64_t sessionid) {
+    asio::post(io_ctx_, [this, serviceid, sender, sessionid] {
+        if (auto s = find_service(serviceid); nullptr != s) {
+            server_->response(
+                sender,
+                moon::format(R"({"name":"%s","serviceid":"%X"},)", s->name().data(), s->id()),
+                sessionid
+            );
+        } else {
+            server_->response(sender, ""sv, sessionid);
+        }
+    });
+}
+
 asio::io_context& worker::io_context() {
     return io_ctx_;
 }

--- a/src/moon/core/worker.h
+++ b/src/moon/core/worker.h
@@ -32,6 +32,8 @@ public:
 
     void scan(uint32_t sender, int64_t sessionid);
 
+    void find(uint32_t serviceid, uint32_t sender, int64_t sessionid);
+
     void send(message&& msg);
 
     void shared(bool v);


### PR DESCRIPTION
add 'find_service' for check whether the specified service exists, and fix 'scan_services' never return bug when workerid not exists